### PR TITLE
Fix error verifying organization request with description

### DIFF
--- a/project/views/manage_admin_unit/templates/manage_admin_unit/incoming_admin_unit_verification_request/review.html
+++ b/project/views/manage_admin_unit/templates/manage_admin_unit/incoming_admin_unit_verification_request/review.html
@@ -1,5 +1,5 @@
 {% extends "generic/update.html" %}
-{% from "_macros.html" import render_admin_unit_badges, render_location_prop, render_roles, render_logo, render_fax_prop, render_jquery_steps_header, render_phone_prop, render_email_prop, render_string_prop, render_field_with_errors, render_field, render_event_props, render_image_with_link, render_place, render_link_prop %}
+{% from "_macros.html" import render_text_prop, render_admin_unit_badges, render_location_prop, render_roles, render_logo, render_fax_prop, render_jquery_steps_header, render_phone_prop, render_email_prop, render_string_prop, render_field_with_errors, render_field, render_event_props, render_image_with_link, render_place, render_link_prop %}
 
 {% block header %}
 {{ super() }}

--- a/tests/views/test_verification_request_review.py
+++ b/tests/views/test_verification_request_review.py
@@ -19,6 +19,13 @@ def test_review_verify(
         unverified_admin_unit_id, verifier_admin_unit_id
     )
 
+    with app.app_context():
+        from project.models import AdminUnit
+
+        admin_unit = db.session.get(AdminUnit, unverified_admin_unit_id)
+        admin_unit.description = "Beschreibung"
+        db.session.commit()
+
     url = utils.get_url(
         "manage_admin_unit.incoming_admin_unit_verification_request_review",
         id=verifier_admin_unit_id,


### PR DESCRIPTION
The changes ensure that the organization request verification process correctly handles the description field. This update includes modifications to the template and adds a test to verify the functionality.

Fixes #636